### PR TITLE
Update rosinstall to point at frc_control melodic-devel

### DIFF
--- a/uwreact_robot.rosinstall
+++ b/uwreact_robot.rosinstall
@@ -1,1 +1,1 @@
-- git: {local-name: frc_control, uri: 'https://github.com/uwreact/frc_control.git', version: kinetic-devel}
+- git: {local-name: frc_control, uri: 'https://github.com/uwreact/frc_control.git', version: melodic-devel}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/uwreact_robot/blob/master/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [ ] I have tested my changes on real hardware. 

Fixes #53, and therefore unblocks #41

Note that once `frc_control` finishes updating to melodic (beyond just renaming the default branch), further changes will be required in `uwreact_robot`. In particular, the Travis CI config will need to specify Melodic rather than Kinetic, otherwise we will mismatch with `frc_control` and the build will fail.