### PR TITLE
Switch from ros-shadow-fixed to ros-testing repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - AFTER_SCRIPT="cd /root/catkin_ws/src/uwreact_robot; ./run_linters.py"
   matrix:
     - ROS_DISTRO="melodic"   ROS_REPO="ros"
-    - ROS_DISTRO="melodic"   ROS_REPO="ros-shadow-fixed"
+    - ROS_DISTRO="melodic"   ROS_REPO="ros-testing"
 
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->

In the follow-up from the security issue on the ROS build farm last week, the `ros-shadow-fixed` repository has been replaced with the `ros-testing` repository.

Details here: https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454

Note that industrial_ci has already updated their codebase upstream and have patched in a redirection from `ros-shadow-fixed` to `ros-testing` for people who are slow to update their configs (like us), which is why we haven't seen any issues yet. 

Note also that, since we use the `stereolabs/zed:ubuntu1804-cuda10.0-zed2.7` docker image rather than the `stereolabs/zed:ubuntu1804-cuda10.0-zed2.7-ros` image, we should still be okay with our docker image. Stereolabs still has not updated their docker images, so I suspect the `-ros` images will have the wrong GPG key for the ROS package servers, but we aren't using these so I believe we will face no issues here.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/uwreact_robot/blob/master/CONTRIBUTING.md) guide.
- [ ] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
- [x] I have tested my changes on real hardware.
