### PR TITLE
Reformat with latest yapf updates

### DIFF
--- a/run_clang_tidy.py
+++ b/run_clang_tidy.py
@@ -97,10 +97,9 @@ def main():
     Main function
     """
 
-    parser = argparse.ArgumentParser(
-        description='Wrapper for running clang-tidy on a catkin workspace.',
-        epilog='Note: In order for clang-tidy to understand which files to tidy, ' +
-        'the workspace must be built with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON.')
+    parser = argparse.ArgumentParser(description='Wrapper for running clang-tidy on a catkin workspace.',
+                                     epilog='Note: In order for clang-tidy to understand which files to tidy, ' +
+                                     'the workspace must be built with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON.')
     parser.add_argument('-f', '--fix', help='Attempt to automatically fix issues', action='store_true')
     parser.add_argument('-j', '--jobs', help='Number of packages to tidy concurrently (default=4)', default=4, type=int)
     parser.add_argument('-q', '--quiet', help='Do not produce any stdout output', action='store_true')


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->

`yapf` changed its default behaviour recently. This causes some previously-conforming code to now fail to pass the linting rules. Normally, I would say this is a bad situation since a 3rd party dependency changed and affected our workflow, but I actually much prefer the new default that `yapf` uses, so I'm not too upset. It also brings the Python and C++ code styles closer to each other, so extra bonus (`AllOnOneLineOrOnePerLine` type of thing).

Note that this PR blocks all other PRs at the moment, since no code can land until our codebase and linters match up again.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/uwreact_robot/blob/master/CONTRIBUTING.md) guide.
- [ ] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
- [ ] I have tested my changes on real hardware.
