### PR TITLE
Update clang-tidy to force braces around bodies

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,6 @@ Checks:  '-*,
           -cppcoreguidelines-pro-bounds-constant-array-index,
           -cppcoreguidelines-pro-type-vararg,
           -modernize-raw-string-literal,
-          -readability-braces-around-statements,
           -readability-misleading-indentation'
 
 ## Disabled to allow ROS logging:
@@ -24,7 +23,6 @@ Checks:  '-*,
 ## Disabled:
 # cppcoreguidelines-pro-bounds-constant-array-index
 # modernize-raw-string-literal
-# readability-braces-around-statements
 
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*/src/uwreact_robot/.*'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->
Replaces #84.

Require braces for all `if`, `while`, `for`, etc statements.

Since we were unable to reach a consensus on whether we should allow single-line blocks without braces, we will err on the side of caution and consistency and enforce all `if` and loop blocks must use braces.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/uwreact_robot/blob/master/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
- [ ] I have tested my changes on real hardware.
